### PR TITLE
Remove `prototype` from namespace

### DIFF
--- a/www/InAppRatingsReview.js
+++ b/www/InAppRatingsReview.js
@@ -3,7 +3,7 @@ function InAppRatingsReview() {
 
 }
 
-InAppRatingsReview.prototype.requestReview = function (successCallback, errorCallback) {
+InAppRatingsReview.requestReview = function (successCallback, errorCallback) {
     cordova.exec(successCallback, errorCallback, 'InAppRatingsReview', 'requestReview', []);
 };
 


### PR DESCRIPTION
No need to include `prototype` from the namespace for `InAppRatingsReview.requestReview`. This will actually make the README more accurate as well.